### PR TITLE
Fix line comments symbol

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "#",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "/*", "*/" ]
     },


### PR DESCRIPTION
In UCF files the line comment symbol is pound (#). So now it replaces "//"
pair which was previously.

Fix #4

Looks better, isn't it?

![ok](https://user-images.githubusercontent.com/8915849/50477805-0a7f9080-09df-11e9-8e3c-cebade67301c.gif)
